### PR TITLE
Fix evaluation of maintainer-packages.nix

### DIFF
--- a/maintainer-packages.nix
+++ b/maintainer-packages.nix
@@ -31,7 +31,7 @@ let
   isMaintainedBy = pkg:
     elem
       myMaintainer
-      (pkg.meta.maintainers or [ ] ++ (flatten (map (x: x.members) (pkg.meta.teams or [ ]))));
+      (pkg.meta.maintainers or [ ] ++ (flatten (map (x: x.members or [ ]) (pkg.meta.teams or [ ]))));
 
   isDerivationRobust = pkg:
     let


### PR DESCRIPTION
I've noticed that the current hydra checks fails because maintainer-packages.nix doesn't evaluate any more. This commit fixes it.

Apparently, entries in nixpgs team list can have no `members` attribute. This is the case for the lua team at the time of writing.
