### PR TITLE
ci(hydra-build-status): show only failed packages

### DIFF
--- a/.github/workflows/hydra-build-status-linux.yml
+++ b/.github/workflows/hydra-build-status-linux.yml
@@ -32,10 +32,9 @@ jobs:
 
       - name: Generate packages file
         run: >
-          nix eval --json --file maintainer-packages.nix --arg showBroken false packages
-          | jq '[.. | objects | select(has("name")) | .name]'
+          nix eval --json --file team-packages.nix --arg showBroken false packages
           > packages.json
 
       - name: Check build status
         run: >
-          nix run .#hydra-build-status -- --platforms ${{ matrix.platform }} --file packages.json > $GITHUB_STEP_SUMMARY
+          nix run .#hydra-build-status -- --platforms ${{ matrix.platform }} --failed-only --file packages.json > $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Use new `team-packages.nix` script.
